### PR TITLE
Added option to pass aws profile to s3PathHandler.

### DIFF
--- a/iopath/common/event_logger.py
+++ b/iopath/common/event_logger.py
@@ -94,5 +94,5 @@ class EventLogger:
 
             for writer in self._writers:
                 writer.writeRecord(topic, self._evt)
-        del self._evt
-        self._evt = SimpleEventRecord()
+            del self._evt
+            self._evt = SimpleEventRecord()

--- a/iopath/common/s3.py
+++ b/iopath/common/s3.py
@@ -86,7 +86,7 @@ class S3PathHandler(PathHandler):
     def __init__(
         self,
         cache_dir: Optional[str] = None,
-        profile: Optional[str] = "default",
+        profile: Optional[str] = "saml",
         transfer_config_kwargs: Optional[Dict] = None,
     ):
         """

--- a/iopath/common/s3.py
+++ b/iopath/common/s3.py
@@ -87,6 +87,7 @@ class S3PathHandler(PathHandler):
     def __init__(
         self,
         cache_dir: Optional[str] = None,
+        profile: Optional[str] = "default",
         transfer_config_kwargs: Optional[Dict] = None,
     ):
         """
@@ -98,6 +99,7 @@ class S3PathHandler(PathHandler):
                 See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3.html for details.
         """
         self.cache_dir = cache_dir
+        self.profile = profile
         from boto3.s3.transfer import TransferConfig
 
         self.transfer_config = TransferConfig(
@@ -131,7 +133,7 @@ class S3PathHandler(PathHandler):
         logger = logging.getLogger(__name__)
         if not hasattr(self, "client"):
             try:
-                session = boto3.Session()
+                session = boto3.Session(profile_name=self.profile)
                 self.client = session.client("s3")
             except botocore.exceptions.NoCredentialsError as e:
                 logger.error(

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -34,9 +34,8 @@ class TestsS3(unittest.TestCase):
     def setUpClass(cls):
         # NOTE: user should change this location.
         cls.s3_bucket = "TEST_BUCKET_NAME_REPLACE_ME"
-        cls.s3_rel_path = os.path.expandvars(
-            "users/$USER/private/home/$USER/.fairseq/test_s3_pathhandler"
-        )
+        # NOTE: user should change this to a valid bucket path that is accessible.
+        cls.s3_rel_path = "TEST_REL_PATH_REPLACE_ME"
         cls.s3_full_path = "s3://" + cls.s3_bucket + "/" + cls.s3_rel_path
         cls.s3_pathhandler = S3PathHandler()
         cls.pathmanager = PathManager()


### PR DESCRIPTION
Added option to pass aws profile to s3PathHandler.

This will allow S3 handler to work with different profile settings.
Also fixed a bug in event logging.

Test plan
----------

Changed S3PathHandler to use profile=saml
(sujittest) sujitv@devfair020:~/code/iopath/tests$  python -m unittest test_s3

----------------------------------------------------------------------
Ran 20 tests in 20.278s

OK