### PR TITLE
Check before trying to delete non existing attribute

### DIFF
--- a/iopath/common/event_logger.py
+++ b/iopath/common/event_logger.py
@@ -105,5 +105,6 @@ class EventLogger:
 
             for writer in self._writers:
                 writer.writeRecord(topic, self._evt)
-            del self._evt
+            if hasattr(self, "_evt"):
+                del self._evt
             self._evt = SimpleEventRecord()


### PR DESCRIPTION
This pull request should fix an issue I encountered when using Pytorch3d.

When executing the following code:

`from iopath.common.file_io import PathManager`
`PathManager().open("dataset/carla/Town01/Lidar 3/00000.ply", "rb")`


The following warning / info is logged:
An exception occurred in telemetry logging.Disabling telemetry to prevent further exceptions.
Traceback (most recent call last):
  File "/home/webersa/miniconda3/envs/IDP/lib/python3.8/site-packages/iopath/common/file_io.py", line 946, in __log_tmetry_keys
    handler.log_event()
  File "/home/webersa/miniconda3/envs/IDP/lib/python3.8/site-packages/iopath/common/event_logger.py", line 97, in log_event
    del self._evt
AttributeError: _evt