### PR TITLE
Using Protocol from typing_extensions. 

### DIFF
--- a/iopath/common/file_io.py
+++ b/iopath/common/file_io.py
@@ -22,12 +22,13 @@ from typing import (
     List,
     MutableMapping,
     Optional,
-    Protocol,
     Set,
     Type,
     TypeVar,
     Union,
 )
+from typing_extensions import Protocol
+
 from urllib.parse import urlparse
 
 import portalocker  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     install_requires=[
         "boto3",
         "tqdm",
+        "typing_extensions",
         "portalocker",
         "dataclasses; python_version<'3.7'",
     ],


### PR DESCRIPTION
This will fix the import errors with Python versions < 3.8.