### PR TITLE
Remove query params while saving files.

### DIFF
--- a/iopath/common/file_io.py
+++ b/iopath/common/file_io.py
@@ -826,6 +826,10 @@ class HTTPURLHandler(PathHandler):
                 get_cache_dir(cache_dir), os.path.dirname(parsed_url.path.lstrip("/"))
             )
             filename = path.split("/")[-1]
+
+            if parsed_url.query:
+                filename = filename.split('?').pop(0)
+
             if len(filename) > self.MAX_FILENAME_LEN:
                 filename = filename[:100] + "_" + uuid.uuid4().hex
 


### PR DESCRIPTION
Sometimes `path` may have additional query parameters (for example `https://dropbox.com/file?dl=1`). This PR removes query parameters (`?dl=1`) from filenames before saving them locally.