### PR TITLE
Update conda install instructions on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ pip install -U iopath
 ### 2. Install from Anaconda Cloud (updated nightly)
 
 ```
-conda install -c conda-forge yacs
-conda install -c iopath iopath
+conda install -c conda-forge iopath    # works for v0.1.10, python 3.12
 ```
 
 ### 3. Install latest from GitHub


### PR DESCRIPTION
For Python 3.12, installing with `conda` (version 25.9.1) from `iopath` channel doesn't work:

```
(my_env) $ conda install -y -c conda-forge yacs && conda install -y -c iopath iopath
2 channel Terms of Service accepted
Channels:
 - conda-forge
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /workspace/epark/miniconda3/envs/my_env

  added / updated specs:
    - yacs


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    pyyaml-6.0.3               |     pyh7db6752_0          44 KB  conda-forge
    yaml-0.2.5                 |       h7f98852_2          87 KB  conda-forge
    ------------------------------------------------------------
                                           Total:         131 KB

The following NEW packages will be INSTALLED:

  pyyaml             conda-forge/noarch::pyyaml-6.0.3-pyh7db6752_0 
  yacs               conda-forge/noarch::yacs-0.1.8-pyh29332c3_2 
  yaml               conda-forge/linux-64::yaml-0.2.5-h7f98852_2 

The following packages will be UPDATED:

  ca-certificates    pkgs/main/linux-64::ca-certificates-2~ --> conda-forge/noarch::ca-certificates-2025.10.5-hbd8a1cb_0 



Downloading and Extracting Packages:
                                                                                                     
Preparing transaction: done                                                                          
Verifying transaction: done
Executing transaction: done
2 channel Terms of Service accepted
Channels:
 - iopath
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package iopath-0.1.1.post20200916-py36 requires python >=3.6,<3.7.0a0, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ iopath =* * is installable with the potential options
│  ├─ iopath [0.1.1.post20200916|0.1.2.post20201116|...|0.1.9] would require
│  │  └─ python >=3.6,<3.7.0a0 *, which can be installed;
│  ├─ iopath [0.1.1.post20200916|0.1.2.post20201116|...|0.1.9] would require
│  │  └─ python >=3.7,<3.8.0a0 *, which can be installed;
│  ├─ iopath [0.1.2.post20201116|0.1.3.post20210120|...|0.1.9] would require
│  │  └─ python >=3.8,<3.9.0a0 *, which can be installed;
│  └─ iopath [0.1.7|0.1.8|0.1.9] would require
│     └─ python >=3.9,<3.10.0a0 *, which can be installed;
└─ pin on python 3.12.* =* * is not installable because it requires
   └─ python =3.12 *, which conflicts with any installable versions previously reported.

Pins seem to be involved in the conflict. Currently pinned specs:
 - python=3.12

```

However, installing from `conda-forge` channel works:

```
(my_env) $ conda install -y -c conda-forge iopath
2 channel Terms of Service accepted
Channels:
 - conda-forge
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /workspace/epark/miniconda3/envs/my_env

  added / updated specs:
    - iopath


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    typing-extensions-4.15.0   |       h396c80c_0          89 KB  conda-forge
    typing_extensions-4.15.0   |     pyhcf101f3_0          50 KB  conda-forge
    ------------------------------------------------------------
                                           Total:         140 KB

The following NEW packages will be INSTALLED:

  colorama           conda-forge/noarch::colorama-0.4.6-pyhd8ed1ab_1 
  dataclasses        conda-forge/noarch::dataclasses-0.8-pyhc8e2a94_3 
  iopath             conda-forge/noarch::iopath-0.1.10-pyhd8ed1ab_0 
  portalocker        conda-forge/noarch::portalocker-1.4.0-py_0 
  tqdm               conda-forge/noarch::tqdm-4.67.1-pyhd8ed1ab_1 
  typing-extensions  conda-forge/noarch::typing-extensions-4.15.0-h396c80c_0 
  typing_extensions  conda-forge/noarch::typing_extensions-4.15.0-pyhcf101f3_0 

The following packages will be UPDATED:

  ca-certificates    pkgs/main/linux-64::ca-certificates-2~ --> conda-forge/noarch::ca-certificates-2025.10.5-hbd8a1cb_0 



Downloading and Extracting Packages:
                                                                                                     
Preparing transaction: done                                                                          
Verifying transaction: done
Executing transaction: done
```